### PR TITLE
✨ Feature - 회원가입 이메일 인증 #5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,10 @@ jobs:
           # application-redis.yml
           touch ./application-redis.yml
           echo "${{ secrets.CI_APPLICATION_REDIS }}" >> ./application-redis.yml
+          
+          # application-email.yml
+          touch ./application-email.yml
+          echo "${{ secrets.APPLICATION_EMAIL }}" >> ./application-email.yml
         shell: bash
 
       - name: Gradle Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
           # application-redis.yml
           touch ./application-redis.yml
           echo "${{ secrets.CI_APPLICATION_REDIS }}" >> ./application-redis.yml
+          
+          # application-email.yml
+          touch ./application-email.yml
+          echo "${{ secrets.APPLICATION_EMAIL }}" >> ./application-email.yml
         shell: bash
 
       - name: Grant Execute Permission For Gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.session:spring-session-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/reachrich/reachrichuser/global/config/EmailConfig.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/config/EmailConfig.java
@@ -1,0 +1,63 @@
+package com.reachrich.reachrichuser.global.config;
+
+import com.reachrich.reachrichuser.global.util.EmailSender;
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@PropertySource("classpath:application-email.yml")
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.protocol}")
+    private String protocol;
+
+    @Value("${spring.mail.default-encoding}")
+    private String defaultEncoding;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        Properties properties = new Properties();
+        properties.put("mail.smtp.starttls.enable", starttls);
+        properties.put("mail.smtp.auth", auth);
+
+        javaMailSender.setProtocol(protocol);
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setDefaultEncoding(defaultEncoding);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(properties);
+
+        return javaMailSender;
+    }
+
+    @Bean
+    public EmailSender emailSender(JavaMailSender javaMailSender) {
+        return new EmailSender(javaMailSender);
+    }
+}

--- a/src/main/java/com/reachrich/reachrichuser/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/config/WebSecurityConfig.java
@@ -84,7 +84,7 @@ public class WebSecurityConfig {
             .authorizeRequests()
             .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
             .antMatchers(
-                "/users/login", "/users/register"
+                "/users/login", "/users/register", "/users/verify-email/**"
             ).permitAll()
             .anyRequest().hasAnyRole("USER")
             .and()

--- a/src/main/java/com/reachrich/reachrichuser/global/exception/ErrorCode.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/exception/ErrorCode.java
@@ -8,7 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 예상치 못한 에러가 발생했습니다."),
-    LOGIN_DENIED(HttpStatus.UNAUTHORIZED, "이메일 혹은 비밀번호가 일치하지 않습니다.");
+
+    // 사용자 관련
+    LOGIN_DENIED(HttpStatus.UNAUTHORIZED, "이메일 혹은 비밀번호가 일치하지 않습니다."),
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+    EMAIL_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+    VERIFY_EMAIL_FAILURE(HttpStatus.UNAUTHORIZED, "이메일 인증에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/reachrich/reachrichuser/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.reachrich.reachrichuser.global.handler;
 
+import static com.reachrich.reachrichuser.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
 import com.reachrich.reachrichuser.global.exception.CustomException;
 import com.reachrich.reachrichuser.global.exception.ErrorCode;
 import com.reachrich.reachrichuser.global.exception.ErrorResponse;
@@ -17,7 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     private ResponseEntity<ErrorResponse> handleException(Exception e) {
-        return handleExceptionInternal(ErrorCode.INTERNAL_SERVER_ERROR);
+        return handleExceptionInternal(INTERNAL_SERVER_ERROR);
     }
 
     private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {

--- a/src/main/java/com/reachrich/reachrichuser/global/util/Const.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/util/Const.java
@@ -4,7 +4,22 @@ public class Const {
 
     // Redis
     public static final String LOGIN_USER = "loginUser";
+    public static final String EMAIL_AUTH = "emailAuth";
+    public static final String EMAIL = "email";
+    public static final String AUTH_CODE = "authCode";
 
     // Spring Security
     public static final String ROLE_USER = "ROLE_USER";
+
+    // Email
+    public static final int AUTH_MAIL_LIMIT_SECONDS = 180;
+
+    // Random Generator
+    public static final int AUTH_CODE_LEN = 6;
+    public static final int DIGIT = 0;
+    public static final int LOWER_CASE = 1;
+    public static final int UPPER_CASE = 2;
+    public static final int LOWER_CASE_START = 97;
+    public static final int UPPER_CASE_START = 65;
+    public static final int ALPHABET_LEN = 26;
 }

--- a/src/main/java/com/reachrich/reachrichuser/global/util/EmailSender.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/util/EmailSender.java
@@ -1,0 +1,36 @@
+package com.reachrich.reachrichuser.global.util;
+
+import static com.reachrich.reachrichuser.global.exception.ErrorCode.EMAIL_SEND_FAILURE;
+
+import com.reachrich.reachrichuser.global.exception.CustomException;
+import javax.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendVerificationEmail(String email, String authCode) {
+        try {
+            String message = createVerificationEmailMessage(authCode);
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+            helper.setTo(email);
+            helper.setSubject("[Reach Rich] 회원가입 인증코드 발송");
+            helper.setText(message, true);
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            log.error("인증 이메일 전송 실패 : {}", e.getMessage());
+            throw new CustomException(EMAIL_SEND_FAILURE);
+        }
+    }
+
+    private String createVerificationEmailMessage(String authCode) {
+        return "<div><h1>" + authCode + "</h1></div>";
+    }
+}

--- a/src/main/java/com/reachrich/reachrichuser/global/util/RandomGenerator.java
+++ b/src/main/java/com/reachrich/reachrichuser/global/util/RandomGenerator.java
@@ -1,0 +1,41 @@
+package com.reachrich.reachrichuser.global.util;
+
+import static com.reachrich.reachrichuser.global.util.Const.ALPHABET_LEN;
+import static com.reachrich.reachrichuser.global.util.Const.AUTH_CODE_LEN;
+import static com.reachrich.reachrichuser.global.util.Const.DIGIT;
+import static com.reachrich.reachrichuser.global.util.Const.LOWER_CASE;
+import static com.reachrich.reachrichuser.global.util.Const.LOWER_CASE_START;
+import static com.reachrich.reachrichuser.global.util.Const.UPPER_CASE;
+import static com.reachrich.reachrichuser.global.util.Const.UPPER_CASE_START;
+
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RandomGenerator {
+
+    public static String generateAuthCode() {
+        return generateAuthCodeInternal(new Random().ints(AUTH_CODE_LEN, 0, 3).boxed());
+    }
+
+    private static String generateAuthCodeInternal(Stream<Integer> typeStream) {
+        Random random = new Random();
+        return typeStream.map(type -> {
+            char c;
+            switch (type) {
+                case DIGIT:
+                    c = Character.forDigit(random.nextInt(10), 10);
+                    break;
+                case LOWER_CASE:
+                    c = (char) (LOWER_CASE_START + random.nextInt(ALPHABET_LEN));
+                    break;
+                case UPPER_CASE:
+                    c = (char) (UPPER_CASE_START + random.nextInt(ALPHABET_LEN));
+                    break;
+                default:
+                    c = '0';
+            }
+            return c;
+        }).map(String::valueOf).collect(Collectors.joining());
+    }
+}

--- a/src/main/java/com/reachrich/reachrichuser/user/controller/UserController.java
+++ b/src/main/java/com/reachrich/reachrichuser/user/controller/UserController.java
@@ -6,6 +6,8 @@ import com.reachrich.reachrichuser.user.service.UserService;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,10 +32,17 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    // TODO: 201로 URI response 할지?
     @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody RegisterDto registerDto) {
-        String nickname = userService.register(registerDto);
+    public ResponseEntity<String> register(HttpSession session,
+        @RequestBody RegisterDto registerDto) {
+
+        String nickname = userService.register(session, registerDto);
         return ResponseEntity.ok(nickname);
+    }
+
+    @GetMapping("/verify-email/{email}")
+    public ResponseEntity<Void> sendAuthEmail(HttpSession session, @PathVariable String email) {
+        userService.sendAuthEmail(session, email);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/reachrich/reachrichuser/user/dto/RegisterDto.java
+++ b/src/main/java/com/reachrich/reachrichuser/user/dto/RegisterDto.java
@@ -8,4 +8,5 @@ public class RegisterDto {
     private String email;
     private String password;
     private String nickname;
+    private String authCode;
 }

--- a/src/main/java/com/reachrich/reachrichuser/user/repository/UserRepository.java
+++ b/src/main/java/com/reachrich/reachrichuser/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/reachrich/reachrichuser/user/service/UserService.java
+++ b/src/main/java/com/reachrich/reachrichuser/user/service/UserService.java
@@ -1,13 +1,24 @@
 package com.reachrich.reachrichuser.user.service;
 
+import static com.reachrich.reachrichuser.global.exception.ErrorCode.DUPLICATED_EMAIL;
+import static com.reachrich.reachrichuser.global.exception.ErrorCode.LOGIN_DENIED;
+import static com.reachrich.reachrichuser.global.exception.ErrorCode.VERIFY_EMAIL_FAILURE;
+import static com.reachrich.reachrichuser.global.util.Const.AUTH_CODE;
+import static com.reachrich.reachrichuser.global.util.Const.AUTH_MAIL_LIMIT_SECONDS;
+import static com.reachrich.reachrichuser.global.util.Const.EMAIL;
+import static com.reachrich.reachrichuser.global.util.Const.EMAIL_AUTH;
 import static com.reachrich.reachrichuser.global.util.Const.LOGIN_USER;
+import static java.util.Objects.isNull;
 
 import com.reachrich.reachrichuser.global.exception.CustomException;
 import com.reachrich.reachrichuser.global.exception.ErrorCode;
+import com.reachrich.reachrichuser.global.util.EmailSender;
+import com.reachrich.reachrichuser.global.util.RandomGenerator;
 import com.reachrich.reachrichuser.user.domain.User;
 import com.reachrich.reachrichuser.user.dto.LoginDto;
 import com.reachrich.reachrichuser.user.dto.RegisterDto;
 import com.reachrich.reachrichuser.user.repository.UserRepository;
+import java.util.Map;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,14 +32,15 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailSender emailSender;
 
     @Transactional(readOnly = true)
     public String login(HttpSession session, LoginDto loginDto) {
         User user = User.fromEntity(userRepository.findByEmail(loginDto.getEmail())
-            .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_DENIED)));
+            .orElseThrow(() -> new CustomException(LOGIN_DENIED)));
 
         if (!user.isPasswordMatch(passwordEncoder, loginDto.getPassword())) {
-            throw new CustomException(ErrorCode.LOGIN_DENIED);
+            throw new CustomException(LOGIN_DENIED);
         }
 
         session.setAttribute(LOGIN_USER, user);
@@ -39,9 +51,42 @@ public class UserService {
         session.removeAttribute(LOGIN_USER);
     }
 
-    // TODO: 이메일 인증 구현
-    public String register(RegisterDto registerDto) {
+    public void sendAuthEmail(HttpSession session, String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(DUPLICATED_EMAIL);
+        }
+
+        String authCode = RandomGenerator.generateAuthCode();
+        emailSender.sendVerificationEmail(email, authCode);
+
+        session.setAttribute(EMAIL_AUTH, Map.of(EMAIL, email, AUTH_CODE, authCode));
+        session.setMaxInactiveInterval(AUTH_MAIL_LIMIT_SECONDS);
+    }
+
+    public String register(HttpSession session, RegisterDto registerDto) {
+        String email = registerDto.getEmail();
+        String authCode = registerDto.getAuthCode();
+
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(DUPLICATED_EMAIL);
+        }
+
+        if (!isEmailAuthenticated(session, email, authCode)) {
+            throw new CustomException(VERIFY_EMAIL_FAILURE);
+        }
+
         User newUser = User.createNewUser(passwordEncoder, registerDto);
         return userRepository.save(newUser.toEntity()).getNickname();
+    }
+
+    private boolean isEmailAuthenticated(HttpSession session, String email, String authCode) {
+        Map<String, String> authMap = (Map<String, String>) session.getAttribute(EMAIL_AUTH);
+        return !isNull(authMap) && verifyEmailAndAuthCode(authMap, email, authCode);
+    }
+
+    private boolean verifyEmailAndAuthCode(Map<String, String> authMap, String email,
+        String authCode) {
+
+        return authMap.get(EMAIL).equals(email) && authMap.get(AUTH_CODE).equals(authCode);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     include:
       - mysql
       - redis
+      - email


### PR DESCRIPTION
### Description
- resolve #5 
- Redis Session, spring-boot-starter-mail, Google SMTP Server
- 이메일 인증 요청 구현
  - 이메일 인증 요청시 6자 인증코드 생성 -> 메일 발송 -> 세션 생성
- 이메일 인증 구현
  - 회원가입 요청 정보(인증코드 포함)로 요청시 세션 검증 후 계정 생성

<br>

### ETC
- [[Reach Rich 개발기] Redis Session을 활용한 이메일 인증 구현](https://velog.io/@pppp0722/Reach-Rich-%EA%B0%9C%EB%B0%9C%EA%B8%B0-Redis-Session%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9D-%EA%B5%AC%ED%98%84)